### PR TITLE
fix(action): make sure curl fails if HTTP server fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,24 @@ jobs:
           set -e
           test "$CI_ISSUE_GIGID" = "1234azertyuiop"
 
+      - name: Clear result file
+        run: rm result.json
+
+      - name: Run action with error scenario ❌
+        id: error500
+        continue-on-error: true
+        uses: ./
+        with:
+          token: fake-valid-token
+          report_paths: zfixtures/junit_example.xml
+          mergify_api_server: http://localhost:1085
+
+      - name: Check error was reported
+        if: ${{ steps.error500.outcome == 'success' }}
+        run: |
+          echo "Error succeeded, that's not correct."
+          exit 1
+
       - name: Dump mockserver logs
         if: always()
         run: |

--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,11 @@ runs:
           exit 1
         fi
 
+        set +e
+
         # TODO(sileht): support multiple files
         curl -X POST \
+          --fail \
           -H "Authorization: bearer ${MERGIFY_CI_ISSUES_TOKEN}" \
           -F name=${WORKFLOW_JOB_NAME} \
           -F provider=github_action \
@@ -56,6 +59,14 @@ runs:
           -F files=@${FILES} \
           -o result.json \
           ${MERGIFY_API_SERVER}/repos/${REPOSITORY}/ci_issues_upload
+
+        if [ $? = 22 ]; then
+           echo "Upload failed"
+           test -f result.json && cat result.json
+           exit 22
+        fi
+
+        set -e
 
         GIGID=$(jq -r .gigid result.json)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,14 @@ services:
       - type: bind
         source: zfixtures
         target: /config
+  mockServerError:
+    image: mockserver/mockserver:5.15.0
+    command: -logLevel DEBUG
+    ports:
+      - 1085:1080
+    environment:
+      MOCKSERVER_INITIALIZATION_JSON_PATH: /config/fake-ci-issue-api-500.json
+    volumes:
+      - type: bind
+        source: zfixtures
+        target: /config

--- a/zfixtures/fake-ci-issue-api-500.json
+++ b/zfixtures/fake-ci-issue-api-500.json
@@ -1,0 +1,11 @@
+[
+  {
+    "httpRequest": {
+      "path": ".*"
+    },
+    "httpResponse": {
+      "statusCode": 500,
+      "body": "Internal Server Error"
+    }
+  }
+]


### PR DESCRIPTION
This avoids curl storing the error in the result.json file.

Fixes MRGFY-4028

Change-Id: I1a5ac6866cd3c8cc10df011cdd10abdf098b7b0c