### PR TITLE
chore: remove unused action output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
   test:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    outputs:
+      job_id: ${{ steps.get-job-id.outputs.job_id }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4.2.2
@@ -49,19 +51,31 @@ jobs:
           docker compose up -d
           sleep 1
           docker compose logs
-      - name: Run action 🔍
-        id: gigid
+      - name: Run action
         uses: ./
         with:
           token: fake-valid-token
           report_paths: zfixtures/junit_example.xml
           mergify_api_server: http://localhost:1080
-      - name: Check GIGID
-        env:
-          CI_ISSUE_GIGID: ${{steps.gigid.outputs.CI_ISSUE_GIGID}}
-        run: |
-          set -e
-          test "$CI_ISSUE_GIGID" = "1234azertyuiop"
+
+      - name: Get job ID
+        id: get-job-id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            // Looks for exact match
+            let job = data.jobs.find(
+              (j) => j.name === context.job
+            )
+            if (!job) {
+              core.error("current job not found");
+            }
+            core.setOutput("job_id", String(job.id));
 
       - name: Clear result file
         run: rm result.json
@@ -85,3 +99,26 @@ jobs:
         if: always()
         run: |
           docker compose logs
+
+  test-annotations:
+    needs: test
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check GIGID
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const annotations = await github.rest.checks.listAnnotations({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: ${{ needs.test.outputs.job_id }},
+            });
+            for (const annotation of annotations.data) {
+              if (annotation.message === "CI_ISSUE_GIGID=1234azertyuiop") {
+                core.info(`Annotations found: ${annotation.message}`)
+                return
+              }
+            }
+            console.log(annotations)
+            throw new Error("Annotations not found")

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,7 @@ shared:
   CheckRuns: &CheckRuns
     - check-success=linters
     - check-success=test
+    - check-success=test-annotations
 
 queue_rules:
   - name: hotfix

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,6 @@ inputs:
     default: https://api.mergify.com/v1
   name:
     description: Name of the current workflow job
-outputs:
-  CI_ISSUE_GIGID:
-    description: Mergify CI Issues CI_ISSUE_GIGID
-    value: ${{ steps.gigid.outputs.CI_ISSUE_GIGID }}
 runs:
   using: composite
   steps:
@@ -72,4 +68,3 @@ runs:
         GIGID=$(jq -r .gigid result.json)
 
         echo "::notice title=CI Issues report::CI_ISSUE_GIGID=$GIGID"
-        echo "CI_ISSUE_GIGID=$GIGID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
CI Issues requires the annotations to be generated, not the action output.
The action output was used for testing purposes, but we should not expose it.
The test has been rewritten to avoid the need of this output.