### PR TITLE
ci: warn when token is unset for scopes upload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,14 @@ runs:
         echo "Created scopes file:"
         cat "$FILE"
 
+    - name: Warn if token is unset for scopes upload
+      shell: bash
+      if: |
+        !inputs.token &&
+        github.event.pull_request &&
+        (inputs.action == 'scopes' || inputs.action == 'scopes-upload')
+      run: echo "::warning::Mergify token is not set, scopes will not be sent to Mergify API"
+
     - name: Upload scopes to Mergify API
       shell: bash
       if: |


### PR DESCRIPTION
Instead of silently skipping the scopes upload step when the token
is not set, emit a visible warning in the GitHub Actions UI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>