### PR TITLE
feat(action): allow pinning mergify-cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ having the same name for all jobs
     # Default: "https://api.mergify.com"
     mergify_api_url: ''
 
+    # Version of mergify-cli to install. Use `latest` to install the latest
+released version without pinning.
+
+    # Type: string
+    # Default: "2026.5.5.4"
+    mergify_cli_version: ''
+
     # Path to the Mergify configuration file
     # Type: string
     mergify_config_path: ''

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,12 @@ inputs:
       'skipped' is treated the same as omitting this input.
   jobs:
     description: List of jobs to wait for completion
+  mergify_cli_version:
+    description: |
+      Version of mergify-cli to install. Use `latest` to install the latest
+      released version without pinning.
+    # renovate: datasource=pypi depName=mergify-cli
+    default: 2026.5.5.4
 outputs:
   scopes:
     description: stringified JSON mapping with names of all scopes matching any of changed files
@@ -80,8 +86,14 @@ runs:
 
     - name: Install dependencies
       shell: bash
+      env:
+        MERGIFY_CLI_VERSION: ${{ inputs.mergify_cli_version }}
       run: |
-        uv tool install mergify-cli
+        if [ -z "$MERGIFY_CLI_VERSION" ] || [ "$MERGIFY_CLI_VERSION" = "latest" ]; then
+          uv tool install mergify-cli
+        else
+          uv tool install "mergify-cli==$MERGIFY_CLI_VERSION"
+        fi
         mergify --version
 
     - shell: bash

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,28 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "prHourlyLimit": 10,
+  "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": { "enabled": true },
+  "packageRules": [
+    {
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": ["mergify-cli"],
+      "minimumReleaseAge": "2 days"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^action\\.yml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z0-9-]+))?\\s+default:\\s*(?<currentValue>[^\\s]+)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Add `mergify_cli_version` input defaulting to 2026.5.5.4. Set to `latest`
or empty to install without a pin.

Also tighten the Renovate config (config:best-practices, chore commit
prefix, 10 PRs/hour cap, 7-day minimum release age, lock file
maintenance, OSV vulnerability alerts) and add a customManager that
auto-bumps the default mergify-cli version from PyPI.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>