### PR TITLE
feat(action): allow pinning mergify-cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ having the same name for all jobs
     # Default: "https://api.mergify.com"
     mergify_api_url: ''
 
+    # Version of mergify-cli to install. Use `latest` to install the latest
+released version without pinning.
+
+    # Type: string
+    # Default: "2026.5.1.1"
+    mergify_cli_version: ''
+
     # Path to the Mergify configuration file
     # Type: string
     mergify_config_path: ''

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,11 @@ inputs:
       'skipped' is treated the same as omitting this input.
   jobs:
     description: List of jobs to wait for completion
+  mergify_cli_version:
+    description: |
+      Version of mergify-cli to install. Use `latest` to install the latest
+      released version without pinning.
+    default: 2026.5.1.1
 outputs:
   scopes:
     description: stringified JSON mapping with names of all scopes matching any of changed files
@@ -80,8 +85,14 @@ runs:
 
     - name: Install dependencies
       shell: bash
+      env:
+        MERGIFY_CLI_VERSION: ${{ inputs.mergify_cli_version }}
       run: |
-        uv tool install mergify-cli
+        if [ -z "$MERGIFY_CLI_VERSION" ] || [ "$MERGIFY_CLI_VERSION" = "latest" ]; then
+          uv tool install mergify-cli
+        else
+          uv tool install "mergify-cli==$MERGIFY_CLI_VERSION"
+        fi
         mergify --version
 
     - shell: bash


### PR DESCRIPTION
Add `mergify_cli_version` input defaulting to 2026.5.5.1. Set to `latest`
to install without a pin.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>