### PR TITLE
chore(renovate): tighten config and auto-update mergify-cli pin

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,7 @@ inputs:
     description: |
       Version of mergify-cli to install. Use `latest` to install the latest
       released version without pinning.
+    # renovate: datasource=pypi depName=mergify-cli
     default: 2026.5.1.1
 outputs:
   scopes:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "prHourlyLimit": 10,
+  "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": { "enabled": true },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^action\\.yml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z0-9-]+))?\\s+default:\\s*(?<currentValue>[^\\s]+)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Switch to config:best-practices, prefix updates with chore, throttle to
10 PRs/hour, require 7-day minimum release age, enable lock file
maintenance, and enable OSV vulnerability alerts.

Add a customManager that bumps the mergify_cli_version default in
action.yml from PyPI when a new mergify-cli release is published.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #198