### PR TITLE
fix(action): allow scopes action to run on push events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More information on https://mergify.com
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 ```yaml
-- uses: Mergifyio/gha-mergify-ci@v16
+- uses: Mergifyio/gha-mergify-ci@v17
   id: gha-mergify-ci
   with:
     # The Mergify CI action:

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
       run: mergify ci git-refs
 
     - name: Detect scopes, head sha and base sha
-      if: github.event.pull_request && inputs.action == 'scopes'
+      if: inputs.action == 'scopes'
       id: scopes-detection
       shell: bash
       env:
@@ -155,16 +155,16 @@ runs:
       shell: bash
       if: |
         !inputs.token &&
-        github.event.pull_request &&
-        (inputs.action == 'scopes' || inputs.action == 'scopes-upload')
+        (inputs.action == 'scopes' ||
+         (inputs.action == 'scopes-upload' && github.event.pull_request))
       run: echo "::warning::Mergify token is not set, scopes will not be sent to Mergify API"
 
     - name: Upload scopes to Mergify API
       shell: bash
       if: |
         inputs.token &&
-        github.event.pull_request &&
-        (inputs.action == 'scopes' || inputs.action == 'scopes-upload')
+        (inputs.action == 'scopes' ||
+         (inputs.action == 'scopes-upload' && github.event.pull_request))
       env:
         MERGIFY_TOKEN: ${{ inputs.token }}
         MERGIFY_API_URL: ${{ inputs.mergify_api_url }}


### PR DESCRIPTION
The `github.event.pull_request` guard added in #154 makes the
`scopes` action no-op on push events. mergify-cli now handles push
events for `scopes`, so the guard blocks the legitimate executions
that broke the deployment flow (INC-1436).

The `scopes-upload` action still needs a pull request context, so
keep the guard there.

Fixes MRGFY-7276

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>