### PR TITLE
docs: regenerate README for v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More information on https://mergify.com
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 ```yaml
-- uses: Mergifyio/gha-mergify-ci@v17
+- uses: Mergifyio/gha-mergify-ci@v18
   id: gha-mergify-ci
   with:
     # The Mergify CI action:


### PR DESCRIPTION
The autodoc CI job runs 'tj-actions/auto-doc' which embeds the current
major version (derived from latest release/tag) into the README usage
snippet. The latest release bumped the major to v18 but README still
referenced @v17, causing the 'autodoc / Verify Changed files' step to
fail on every new PR.

Required so that #212 (cooldown PR) can pass CI.