### PR TITLE
ci: fix autodoc release PR branch name rejected by ruleset

### DIFF
--- a/.github/workflows/autodoc.yaml
+++ b/.github/workflows/autodoc.yaml
@@ -32,4 +32,4 @@ jobs:
           title: "chore: update documentation for ${{ github.event.release.tag_name }}"
           body: |
             Auto-generated documentation update after release ${{ github.event.release.tag_name }}.
-          branch: autodoc/update-${{ github.event.release.tag_name }}
+          branch: devs/autodoc/update-${{ github.event.release.tag_name }}


### PR DESCRIPTION
The "Update documentation" workflow runs on release and uses
peter-evans/create-pull-request to push a branch named
"autodoc/update-<tag>". The repo's branch ruleset only permits the
"devs/**" prefix, so the push is rejected with:

    remote: error: GH013: Repository rule violations found for
    refs/heads/autodoc/update-v18

This is why the v18 README update never opened automatically and had to
be regenerated by hand. Prefix the branch with "devs/" so it satisfies
the ruleset.

Failing run: https://github.com/Mergifyio/gha-mergify-ci/actions/runs/26036675646/job/76536631451

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>