### PR TITLE
docs: add CLAUDE.md with mergify stack convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Project conventions
+
+## Git / PRs: always use `mergify stack`
+
+Push and manage all branches and pull requests with the Mergify Stack workflow.
+
+- **Push** with `mergify stack push` — never `git push`.
+- **Create PRs** through `mergify stack push` — never `gh pr create`.
+- **Fix a commit** by amending it (`git commit --amend`) — don't pile on "fix" commits.
+- The PR title/body come from the commit message, so write commit messages as PR descriptions.
+- PRs stay as drafts; the human takes them out of draft.
+- Branch names must use the `devs/**` prefix — the repo ruleset rejects other prefixes.


### PR DESCRIPTION
Record the project convention that all branches and PRs go through the
Mergify Stack workflow (mergify stack push, not git push / gh pr create),
and that branch names must use the devs/** prefix required by the repo
ruleset.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>