### PR TITLE
ci: disable yamllint line-length rule

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -17,8 +17,10 @@ rules:
   # https://github.com/adrienverge/yamllint/issues/141
   # https://github.com/adrienverge/yamllint/issues/384
   comments-indentation: disable
-  line-length:
-    max: 110
+  # Renovate pins actions/images to digests, producing lines that exceed any
+  # sensible width (e.g. docker://...@sha256:<64 hex>). Disable the check so
+  # renovate can pin freely without per-line opt-outs.
+  line-length: disable
   quoted-strings:
     quote-type: double
     required: only-when-needed


### PR DESCRIPTION
Renovate pins actions and docker images to digests, producing lines that
exceed any sensible width (e.g. docker://...@sha256:<64 hex>). Disable
yamllint's line-length rule so renovate can pin freely, without per-line
opt-outs that would have to be added on every future pin across any YAML
file.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>