### PR TITLE
chore(deps): update dependency mergify-cli to v2026.5.29.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ having the same name for all jobs
 released version without pinning.
 
     # Type: string
-    # Default: "2026.5.5.4"
+    # Default: "2026.5.29.2"
     mergify_cli_version: ''
 
     # Path to the Mergify configuration file

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
       Version of mergify-cli to install. Use `latest` to install the latest
       released version without pinning.
     # renovate: datasource=pypi depName=mergify-cli
-    default: 2026.5.5.4
+    default: 2026.5.29.2
 outputs:
   scopes:
     description: stringified JSON mapping with names of all scopes matching any of changed files


### PR DESCRIPTION
Regenerate README.md via ./generate-doc.sh so the autodoc check passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>