### PR TITLE
fix: upgrade mergify-cli on the `latest` path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,10 @@ runs:
         MERGIFY_CLI_VERSION: ${{ inputs.mergify_cli_version }}
       run: |
         if [ -z "$MERGIFY_CLI_VERSION" ] || [ "$MERGIFY_CLI_VERSION" = "latest" ]; then
-          uv tool install mergify-cli
+          # --upgrade implies --refresh, so uv re-resolves against PyPI and
+          # installs the newest release even on persistent self-hosted runners
+          # where an older mergify-cli is already cached.
+          uv tool install --upgrade mergify-cli
         else
           uv tool install "mergify-cli==$MERGIFY_CLI_VERSION"
         fi


### PR DESCRIPTION
When `mergify_cli_version` is `latest` (or empty), the install step ran
`uv tool install mergify-cli` with no `--upgrade`. `uv tool install` is
idempotent: if the tool already exists it prints "`mergify-cli` is already
installed" and does nothing — it does not upgrade.

On persistent self-hosted runners, uv's tool directory
(`~/.local/share/uv/tools`) survives between jobs, so an old mergify-cli
from a prior run lingers. `latest` then silently pins to whatever version
was first installed on that runner instead of the real newest release.

Add `--upgrade` (which implies `--refresh`) so uv re-resolves against PyPI
and installs the newest release even when a cached copy is present. Pinned
`==X` jobs are unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>