### PR TITLE
docs: regenerate README for v19

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More information on https://mergify.com
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 ```yaml
-- uses: Mergifyio/gha-mergify-ci@v18
+- uses: Mergifyio/gha-mergify-ci@v19
   id: gha-mergify-ci
   with:
     # The Mergify CI action:


### PR DESCRIPTION
Bump the action usage version in the README from v18 to v19 following the
v19 release. This is the doc update that the release "Update documentation"
workflow normally opens automatically, but that job is currently failing on
the branch push (the create-pull-request branch is rejected by the org
branch ruleset), so this PR carries the change by hand.