### PR TITLE
ci: replace tj-actions doc tooling with an in-repo generator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,26 +44,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Run auto-doc
-        uses: tj-actions/auto-doc@b10ceedffd794ec29a8fa8700529f40c1b64a951 # v3.6.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          col_max_words: 120
-          markdown_links: false
+          enable-cache: false
+
+      - name: Regenerate documentation
+        run: ./generate-doc.sh
 
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20
-        id: verify-changed-files
-        with:
-          files: |
-            README.md
-          fail-if-changed: true
-          fail-message: Action documentation is out of date. Run `./generate-doc.sh`
-
-      - name: Display diff
-        if: failure()
         run: |
-          git diff
-          exit 1
+          if ! git diff --exit-code -- README.md; then
+            echo "::error::Action documentation is out of date. Run \`./generate-doc.sh\`"
+            exit 1
+          fi
 
 
   test-scopes:

--- a/README.md
+++ b/README.md
@@ -25,27 +25,17 @@ Need help setting it up? See the [GitHub Actions setup guide](https://docs.mergi
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|        INPUT        |  TYPE  | REQUIRED |           DEFAULT           |                                            DESCRIPTION                                            |
-|---------------------|--------|----------|-----------------------------|---------------------------------------------------------------------------------------------------|
-|       action        | string |  false   |      `"junit-process"`      | The Mergify CI action: * junit-process: process JUnit XML files with Mergify CI Insights (Upload  |
-|                     |        |          |                             |     and Quarantine) * scopes: detect and upload pull requests scopes to Mergify Merge Queue *     |
-|                     |        |          |                             | scopes-git-refs: return the base/head git references of the pull request in Merge Queue context * |
-|                     |        |          |                             | scopes-upload: upload pull requests scopes to Mergify Merge Queue * wait-jobs: wait for specified |
-|                     |        |          |                             |                                jobs to complete before proceeding                                 |
-|      job_name       | string |  false   |                             |                Override the job name, must be used in case of matrix job to avoid                 |
-|                     |        |          |                             |                                having the same name for all jobs                                  |
-|        jobs         | string |  false   |                             |                                List of jobs to wait for completion                                |
-|   mergify_api_url   | string |  false   | `"https://api.mergify.com"` |                                      URL of the Mergify API                                       |
-| mergify_cli_version | string |  false   |       `"2026.5.29.2"`       |               Version of mergify-cli to install. Use `latest` to install the latest               |
-|                     |        |          |                             |                                released version without pinning.                                  |
-| mergify_config_path | string |  false   |                             |                              Path to the Mergify configuration file                               |
-|     report_path     | string |  false   |                             |                                    Path of the files to upload                                    |
-|       scopes        | string |  false   |                             |                             Comma separated list of scopes to upload                              |
-|  test_step_outcome  | string |  false   |                             |               Outcome of the test runner step (e.g. steps.<id>.outcome). Pass this                |
-|                     |        |          |                             |               to detect silent failures where the test runner crashed but the JUnit               |
-|                     |        |          |                             |                 report appears clean. Values: 'success', 'failure', 'cancelled',                  |
-|                     |        |          |                             |              'skipped', or omit entirely. 'skipped' is treated the same as omitting               |
-|                     |        |          |                             |                                           this input.                                             |
-|        token        | string |  false   |                             |                                         Mergify CI token                                          |
+| Input | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `action` | string | false | `junit-process` | The Mergify CI action:<br>• junit-process: process JUnit XML files with Mergify CI Insights (Upload and Quarantine)<br>• scopes: detect and upload pull requests scopes to Mergify Merge Queue<br>• scopes-git-refs: return the base/head git references of the pull request in Merge Queue context<br>• scopes-upload: upload pull requests scopes to Mergify Merge Queue<br>• wait-jobs: wait for specified jobs to complete before proceeding |
+| `job_name` | string | false |  | Override the job name, must be used in case of matrix job to avoid having the same name for all jobs |
+| `jobs` | string | false |  | List of jobs to wait for completion |
+| `mergify_api_url` | string | false | `https://api.mergify.com` | URL of the Mergify API |
+| `mergify_cli_version` | string | false | `2026.5.29.2` | Version of mergify-cli to install. Use `latest` to install the latest released version without pinning. |
+| `mergify_config_path` | string | false |  | Path to the Mergify configuration file |
+| `report_path` | string | false |  | Path of the files to upload |
+| `scopes` | string | false |  | Comma separated list of scopes to upload |
+| `test_step_outcome` | string | false |  | Outcome of the test runner step (e.g. steps.<id>.outcome). Pass this to detect silent failures where the test runner crashed but the JUnit report appears clean. Values: 'success', 'failure', 'cancelled', 'skipped', or omit entirely. 'skipped' is treated the same as omitting this input. |
+| `token` | string | false |  | Mergify CI token |
 
 <!-- AUTO-DOC-INPUT:END -->

--- a/generate-doc.py
+++ b/generate-doc.py
@@ -1,0 +1,74 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""Generate the README Inputs table from action.yml.
+
+Replaces tj-actions/auto-doc: parses the action's inputs and rewrites the
+GitHub-flavoured Markdown table between the AUTO-DOC-INPUT markers in README.md.
+"""
+
+import pathlib
+import re
+
+import yaml
+
+ROOT = pathlib.Path(__file__).parent
+ACTION = ROOT / "action.yml"
+README = ROOT / "README.md"
+START = "<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->"
+END = "<!-- AUTO-DOC-INPUT:END -->"
+
+
+def render_description(text: str) -> str:
+    """Render an action.yml description as a single Markdown table cell.
+
+    Wrapped prose lines are joined with spaces; `*`-prefixed lines (e.g. the
+    list of actions) become `<br>`-separated bullets so they render as a list
+    inside the cell rather than a run of literal asterisks.
+    """
+    parts: list[str] = []
+    for raw in text.strip().splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("* "):
+            parts.append("<br>• " + line[2:].strip())
+        elif parts:
+            parts[-1] += " " + line
+        else:
+            parts.append(line)
+    return "".join(parts)
+
+
+def render_table(inputs: dict) -> str:
+    rows = [
+        "| Input | Type | Required | Default | Description |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for name in sorted(inputs):
+        spec = inputs[name] or {}
+        required = "true" if spec.get("required") else "false"
+        default = spec.get("default")
+        default_cell = f"`{default}`" if default not in (None, "") else ""
+        description = render_description(str(spec.get("description", "")))
+        rows.append(f"| `{name}` | string | {required} | {default_cell} | {description} |")
+    return "\n".join(rows)
+
+
+def main() -> None:
+    action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+    table = render_table(action.get("inputs") or {})
+    block = f"{START}\n\n{table}\n\n{END}"
+
+    readme = README.read_text(encoding="utf-8")
+    pattern = re.escape(START) + r".*?" + re.escape(END)
+    if not re.search(pattern, readme, flags=re.DOTALL):
+        raise SystemExit("AUTO-DOC-INPUT markers not found in README.md")
+
+    new = re.sub(pattern, lambda _: block, readme, flags=re.DOTALL)
+    README.write_text(new, encoding="utf-8", newline="\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate-doc.sh
+++ b/generate-doc.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-command -v auto-doc >/dev/null 2>&1 || { echo "auto-doc is not installed" >&2; exit 1; }
+command -v uv >/dev/null 2>&1 || { echo "uv is not installed: https://docs.astral.sh/uv/" >&2; exit 1; }
 
-auto-doc -f action.yml --colMaxWords 120
+exec uv run "$(dirname "$0")/generate-doc.py"


### PR DESCRIPTION
Drop both tj-actions dependencies from the autodoc workflow:

* tj-actions/auto-doc, which generated the README Inputs table
* tj-actions/verify-changed-files, which checked it was committed

tj-actions was the target of a supply-chain compromise (CVE-2025-30066),
so removing it shrinks our exposure. Neither action was pulling its weight:
the whole flow is "render a table from action.yml, fail if it drifts".

Replace it with generate-doc.py, a small PEP-723 script (pyyaml via
`uv run`) that parses action.yml and rewrites the GFM table between the
AUTO-DOC-INPUT markers. generate-doc.sh now calls it instead of the
auto-doc binary, so the local `./generate-doc.sh` workflow is unchanged.
The README table is regenerated into a clean one-row-per-input format
that renders identically on GitHub.

The autodoc CI job now just installs uv, runs the generator, and
`git diff --exit-code` on README.md. The only remaining third-party action
is astral-sh/setup-uv, already trusted and used by action.yml itself.