### PR TITLE
chore(deps): update dependency mergify-cli to v2026.6.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Need help setting it up? See the [GitHub Actions setup guide](https://docs.mergi
 | `job_name` | string | false |  | Override the job name, must be used in case of matrix job to avoid having the same name for all jobs |
 | `jobs` | string | false |  | List of jobs to wait for completion |
 | `mergify_api_url` | string | false | `https://api.mergify.com` | URL of the Mergify API |
-| `mergify_cli_version` | string | false | `2026.5.29.2` | Version of mergify-cli to install. Use `latest` to install the latest released version without pinning. |
+| `mergify_cli_version` | string | false | `2026.6.2.4` | Version of mergify-cli to install. Use `latest` to install the latest released version without pinning. |
 | `mergify_config_path` | string | false |  | Path to the Mergify configuration file |
 | `report_path` | string | false |  | Path of the files to upload |
 | `scopes` | string | false |  | Comma separated list of scopes to upload |

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
       Version of mergify-cli to install. Use `latest` to install the latest
       released version without pinning.
     # renovate: datasource=pypi depName=mergify-cli
-    default: 2026.5.29.2
+    default: 2026.6.2.4
 outputs:
   scopes:
     description: stringified JSON mapping with names of all scopes matching any of changed files


### PR DESCRIPTION
Supersedes #207.

Renovate's #207 only bumped the `mergify_cli_version` default in `action.yml`. That leaves the auto-generated `README.md` inputs table out of sync, so the `autodoc` check (which regenerates the docs and verifies no diff) fails — and `all-greens` fails with it.

This PR makes the same dependency bump **and** regenerates the `README.md` table entry, so autodoc passes.

## Changes
- `action.yml`: `mergify_cli_version` default `2026.5.29.2` → `2026.6.2.4`
- `README.md`: matching auto-doc table update

🤖 Generated with [Claude Code](https://claude.com/claude-code)