### PR TITLE
feat(scopes): forward --base/--head to `mergify ci scopes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Need help setting it up? See the [GitHub Actions setup guide](https://docs.mergi
 | Input | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `action` | string | false | `junit-process` | The Mergify CI action:<br>• junit-process: process JUnit XML files with Mergify CI Insights (Upload and Quarantine)<br>• scopes: detect and upload pull requests scopes to Mergify Merge Queue<br>• scopes-git-refs: return the base/head git references of the pull request in Merge Queue context<br>• scopes-upload: upload pull requests scopes to Mergify Merge Queue<br>• wait-jobs: wait for specified jobs to complete before proceeding |
+| `base` | string | false |  | Base git reference for scope detection (action: scopes). Overrides the automatic push/pull-request detection. Leave unset to auto-detect. |
+| `head` | string | false |  | Head git reference for scope detection (action: scopes). Defaults to HEAD. Leave unset to auto-detect. |
 | `job_name` | string | false |  | Override the job name, must be used in case of matrix job to avoid having the same name for all jobs |
 | `jobs` | string | false |  | List of jobs to wait for completion |
 | `mergify_api_url` | string | false | `https://api.mergify.com` | URL of the Mergify API |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,14 @@ inputs:
     description: Comma separated list of scopes to upload
   mergify_config_path:
     description: Path to the Mergify configuration file
+  base:
+    description: |
+      Base git reference for scope detection (action: scopes). Overrides the
+      automatic push/pull-request detection. Leave unset to auto-detect.
+  head:
+    description: |
+      Head git reference for scope detection (action: scopes). Defaults to
+      HEAD. Leave unset to auto-detect.
   test_step_outcome:
     description: |
       Outcome of the test runner step (e.g. steps.<id>.outcome).
@@ -130,7 +138,13 @@ runs:
       shell: bash
       env:
         MERGIFY_CONFIG_PATH: ${{ inputs.mergify_config_path }}
-      run: mergify ci scopes --write $RUNNER_TEMP/mergify-scopes.json
+        BASE: ${{ inputs.base }}
+        HEAD: ${{ inputs.head }}
+      run: |
+        args=(--write "$RUNNER_TEMP/mergify-scopes.json")
+        [ -n "$BASE" ] && args+=(--base "$BASE")
+        [ -n "$HEAD" ] && args+=(--head "$HEAD")
+        mergify ci scopes "${args[@]}"
 
     - name: Upload scopes to Mergify API
       shell: bash


### PR DESCRIPTION
Add optional `base` and `head` inputs to the `scopes` action and forward
them to `mergify ci scopes`. The CLI already supports them (manual
ReferencesSource); the action just didn't expose them. When unset, behavior
is unchanged (the CLI auto-detects from the push/pull-request event), so this
is fully backward-compatible.

This lets a caller detect scopes against a custom base, e.g. a deploy
pipeline diffing against the last successfully deployed commit instead of a
single push's before->after delta.

Fixes MRGFY-7561

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>