### PR TITLE
fix(renovate): bump mergify-cli in README table and self-ref action version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
       "matchDatasources": ["pypi"],
       "matchPackageNames": ["mergify-cli"],
       "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "Bump the self-referenced action version immediately: it is our own freshly-released major (README example + ci.yaml dogfooding), so the third-party stability wait is pointless.",
+      "matchDepNames": ["Mergifyio/gha-mergify-ci"],
+      "minimumReleaseAge": "0"
     }
   ],
   "customManagers": [
@@ -25,6 +30,31 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z0-9-]+))?\\s+default:\\s*(?<currentValue>[^\\s]+)"
       ]
+    },
+    {
+      "description": "Keep the auto-generated README inputs table in sync with the mergify_cli_version default in action.yml, so the bump PR lands both files in one go and the autodoc check passes.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `mergify_cli_version` \\| string \\| \\w+ \\| `(?<currentValue>[^`]+)` \\|"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "mergify-cli"
+    },
+    {
+      "description": "Bump the self-referenced action version pinned in the README usage example on each new gha-mergify-ci release.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "uses: Mergifyio/gha-mergify-ci@(?<currentValue>v\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "Mergifyio/gha-mergify-ci",
+      "versioningTemplate": "github-actions"
     }
   ]
 }


### PR DESCRIPTION
Two long-standing gaps in the Renovate config:

1. mergify-cli bump PRs fail the autodoc check. The customManager bumps
   the `mergify_cli_version` default in action.yml, but the generated
   README inputs table embeds that same default. Renovate only touched
   action.yml, so `./generate-doc.sh` produced a diff and the autodoc job
   went red on every bump (see #207, manually superseded by #244). Add a
   README customManager for the table row so both files land in one PR at
   the same version and autodoc passes.

2. The self-referenced action version is never bumped in the README usage
   example. The homegrown release workflow that did this was removed in
   #235 (github-actions[bot] can't create branches under the org
   rulesets). Renovate runs as the Mergify app and has no such limit, so
   track Mergifyio/gha-mergify-ci via github-tags and bump the @vNN pin in
   the README. Scope minimumReleaseAge to 0 for this dep: it is our own
   freshly-cut release (already CI-passed), so the 7-day third-party
   stability wait is pointless. This also unblocks the ci.yaml self-test
   pin, currently stuck at v19 while v20/v21/v22 sit behind the window.

Validated with renovate-config-validator and a local dry-run: mergify-cli
resolves to one branch touching both action.yml and README.md at the same
version, and gha-mergify-ci resolves v19 -> v22 with the stability wait
skipped.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>