### PR TITLE
feat: expose test_results_upload output for junit-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,28 @@ Need help setting it up? See the [GitHub Actions setup guide](https://docs.mergi
 | `token` | string | false |  | Mergify CI token |
 
 <!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `test_results_upload` | Outcome of the JUnit test-results upload to Mergify Test Insights (action: junit-process): `success`, `rejected` (the API refused the upload, e.g. a token without CI Insights access — no test data was recorded) or `failed` (transient upload error). Empty when the junit-process step did not run or the installed mergify-cli predates this output. |
+| `scopes` | Stringified JSON mapping with names of all scopes matching any of the changed files |
+| `base` | The Merge Queue-aware base SHA of the pull request |
+| `head` | The Merge Queue-aware head SHA of the pull request |
+
+A rejected upload does not fail the step — Mergify-side trouble must not break your CI. To surface dead ingest in your workflow, check the output explicitly:
+
+```yaml
+- uses: Mergifyio/gha-mergify-ci@v22
+  id: mergify-ci
+  with:
+    action: junit-process
+    token: ${{ secrets.MERGIFY_TOKEN }}
+    report_path: "**/junit*.xml"
+
+- if: steps.mergify-ci.outputs.test_results_upload == 'rejected'
+  run: |
+    echo "Test results upload was rejected — check the MERGIFY_TOKEN permissions."
+    exit 1
+```

--- a/action.yml
+++ b/action.yml
@@ -54,14 +54,23 @@ inputs:
     # renovate: datasource=pypi depName=mergify-cli
     default: 2026.6.5.1
 outputs:
+  test_results_upload:
+    description: |
+      Outcome of the JUnit test-results upload to Mergify Test Insights
+      (action: junit-process): 'success', 'rejected' (the API refused the
+      upload, e.g. a token without CI Insights access — no test data was
+      recorded) or 'failed' (transient upload error). Empty when the
+      junit-process step did not run or the installed mergify-cli predates
+      this output.
+    value: ${{ steps.junit-process.outputs.test_results_upload }}
   scopes:
-    description: stringified JSON mapping with names of all scopes matching any of changed files
+    description: stringified JSON mapping with names of all scopes matching any of the changed files
     value: ${{ steps.scopes-detection.outputs.scopes }}
   base:
-    description: The Merge Queue aware base sha of the pull request
+    description: The Merge Queue-aware base SHA of the pull request
     value: ${{ steps.git-refs-detection.outputs.base || steps.scopes-detection.outputs.base }}
   head:
-    description: The Merge Queue aware head sha of the pull request
+    description: The Merge Queue-aware head SHA of the pull request
     value: ${{ steps.git-refs-detection.outputs.head || steps.scopes-detection.outputs.head }}
 runs:
   using: composite


### PR DESCRIPTION
Since Mergifyio/mergify-cli#1572, `mergify ci junit-process` appends
`test_results_upload=success|rejected|failed` to `$GITHUB_OUTPUT`.
Composite actions don't forward inner step outputs automatically, so
map it to a declared action output. This gives workflows a documented,
programmatic way to detect dead ingest (e.g. a token without CI
Insights access silently dropping test data) without failing the step.

The output is empty when the junit-process step doesn't run or when
the pinned mergify-cli predates the CLI-side change, so this is safe
to ship ahead of the next mergify-cli release.

Also documents the action's outputs in the README, including the
previously-undocumented scopes/base/head.

Fixes Mergifyio/mergify-cli#1571 (action side)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>