### PR TITLE
refactor: install Mergify CLI via Mergifyio/setup-cli action

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Need help setting it up? See the [GitHub Actions setup guide](https://docs.mergi
 | `job_name` | string | false |  | Override the job name, must be used in case of matrix job to avoid having the same name for all jobs |
 | `jobs` | string | false |  | List of jobs to wait for completion |
 | `mergify_api_url` | string | false | `https://api.mergify.com` | URL of the Mergify API |
-| `mergify_cli_version` | string | false | `2026.6.8.1` | Version of mergify-cli to install. Use `latest` to install the latest released version without pinning. |
+| `mergify_cli_version` | string | false |  | Version of mergify-cli to install. Use `latest` to install the latest released version without pinning. Leave unset to use the version pinned by Mergifyio/setup-cli. |
 | `mergify_config_path` | string | false |  | Path to the Mergify configuration file |
 | `report_path` | string | false |  | Path of the files to upload |
 | `scopes` | string | false |  | Comma separated list of scopes to upload |

--- a/action.yml
+++ b/action.yml
@@ -50,9 +50,8 @@ inputs:
   mergify_cli_version:
     description: |
       Version of mergify-cli to install. Use `latest` to install the latest
-      released version without pinning.
-    # renovate: datasource=pypi depName=mergify-cli
-    default: 2026.6.8.1
+      released version without pinning. Leave unset to use the version pinned
+      by Mergifyio/setup-cli.
 outputs:
   test_results_upload:
     description: |
@@ -90,31 +89,20 @@ runs:
         echo "Valid actions are: junit-process, scopes, scopes-git-refs, scopes-upload, wait-jobs"
         exit 1
 
-    - name: Setup Python 🔧
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+    # Install the Mergify CLI through the shared setup-cli action. The version
+    # pin lives in Mergifyio/setup-cli (Renovate-managed there), so an unset
+    # mergify_cli_version must fall through to setup-cli's own default instead of
+    # being forwarded as an empty string, which setup-cli reads as "latest".
+    # Hence two variants: forward an explicit value, or call with no version.
+    - name: Setup Mergify CLI 🔧
+      if: inputs.mergify_cli_version != ''
+      uses: Mergifyio/setup-cli@2440cd0d54c1350f0a72b42952146c95b46d1623 # v1
       with:
-        python-version: "3.14"
+        mergify_cli_version: ${{ inputs.mergify_cli_version }}
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      with:
-        # mergify is too small to benefit + there is no version lock (so no cache key either)
-        enable-cache: false
-
-    - name: Install dependencies
-      shell: bash
-      env:
-        MERGIFY_CLI_VERSION: ${{ inputs.mergify_cli_version }}
-      run: |
-        if [ -z "$MERGIFY_CLI_VERSION" ] || [ "$MERGIFY_CLI_VERSION" = "latest" ]; then
-          # --upgrade implies --refresh, so uv re-resolves against PyPI and
-          # installs the newest release even on persistent self-hosted runners
-          # where an older mergify-cli is already cached.
-          uv tool install --upgrade mergify-cli
-        else
-          uv tool install "mergify-cli==$MERGIFY_CLI_VERSION"
-        fi
-        mergify --version
+    - name: Setup Mergify CLI (pinned default) 🔧
+      if: inputs.mergify_cli_version == ''
+      uses: Mergifyio/setup-cli@2440cd0d54c1350f0a72b42952146c95b46d1623 # v1
 
     - shell: bash
       id: junit-process

--- a/renovate.json
+++ b/renovate.json
@@ -11,38 +11,12 @@
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
-      "matchDatasources": ["pypi"],
-      "matchPackageNames": ["mergify-cli"],
-      "minimumReleaseAge": "2 days"
-    },
-    {
-      "description": "Bump the self-referenced action version immediately: it is our own freshly-released major (README example + ci.yaml dogfooding), so the third-party stability wait is pointless.",
-      "matchDepNames": ["Mergifyio/gha-mergify-ci"],
+      "description": "Bump our own freshly-released majors immediately (Mergifyio/gha-mergify-ci self-reference + the Mergifyio/setup-cli action we consume), so the third-party stability wait is pointless.",
+      "matchDepNames": ["Mergifyio/gha-mergify-ci", "Mergifyio/setup-cli"],
       "minimumReleaseAge": "0"
     }
   ],
   "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^action\\.yml$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z0-9-]+))?\\s+default:\\s*(?<currentValue>[^\\s]+)"
-      ]
-    },
-    {
-      "description": "Keep the auto-generated README inputs table in sync with the mergify_cli_version default in action.yml, so the bump PR lands both files in one go and the autodoc check passes.",
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^README\\.md$/"
-      ],
-      "matchStrings": [
-        "\\| `mergify_cli_version` \\| string \\| \\w+ \\| `(?<currentValue>[^`]+)` \\|"
-      ],
-      "datasourceTemplate": "pypi",
-      "depNameTemplate": "mergify-cli"
-    },
     {
       "description": "Bump the self-referenced action version pinned in the README usage example on each new gha-mergify-ci release.",
       "customType": "regex",


### PR DESCRIPTION
Replace the three inline install steps (setup-python, setup-uv, the
uv tool install block) with a single `uses: Mergifyio/setup-cli@v1`,
moving the mergify-cli version pin + its Renovate anchor and custom
managers out of this repo (now owned by setup-cli).

The `mergify_cli_version` input stays as the public interface, but its
default is dropped: an unset value now falls through to setup-cli's
pinned default. Because GitHub Actions only applies a called action's
input default when the key is omitted (an empty string is "provided",
and setup-cli reads empty as "latest"), the call is split into two
mutually exclusive steps so an unset input resolves to setup-cli's pin
rather than latest. Behavior is identical for every caller config.

renovate.json drops the action.yml/README custom managers that bumped
the local pin and adds Mergifyio/setup-cli to the immediate-bump rule.

Fixes MRGFY-7628

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>