### PR TITLE
feat(scopes): add all_scopes input to flag a PR as impacting all scopes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,19 @@ jobs:
           scopes: scope1,scope2
           mergify_config_path: zfixtures/mergify.yml
 
+      # all_scopes needs a mergify-cli newer than the setup-cli pin, hence
+      # mergify_cli_version: latest. No scopes input: an all-scopes pull
+      # request may carry no concrete scope, exercising the empty-list path.
+      - name: Trying action scopes-upload with all_scopes
+        id: scopes-upload-all
+        uses: ./
+        with:
+          action: scopes-upload
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          all_scopes: true
+          mergify_config_path: zfixtures/mergify.yml
+          mergify_cli_version: latest
+
       - name: Trying action scopes
         id: scopes-detection
         uses: ./

--- a/README.md
+++ b/README.md
@@ -21,6 +21,43 @@ Pin the action to a released version (see the [releases](https://github.com/Merg
 
 Need help setting it up? See the [GitHub Actions setup guide](https://docs.mergify.com/ci-insights/setup/github-actions/) on the Mergify docs.
 
+## Merge Queue scopes
+
+Scopes tell the Mergify Merge Queue which parts of the repository a pull
+request impacts, so batches with disjoint scopes can merge in parallel. Use
+`action: scopes` to detect them from the Mergify configuration file filters,
+or `action: scopes-upload` to upload a list you computed yourself (e.g. the
+leaf targets of your build graph):
+
+```yaml
+- uses: Mergifyio/gha-mergify-ci@v22
+  with:
+    action: scopes-upload
+    token: ${{ secrets.MERGIFY_TOKEN }}
+    scopes: backend,frontend
+```
+
+### Catch-all: declaring a pull request impacts all scopes
+
+Some pull requests impact everything — typically a build-system or CI
+configuration change — and enumerating every scope is brittle. Set
+`all_scopes: true` to declare it explicitly:
+
+```yaml
+- uses: Mergifyio/gha-mergify-ci@v22
+  with:
+    action: scopes-upload
+    token: ${{ secrets.MERGIFY_TOKEN }}
+    all_scopes: true
+```
+
+The Merge Queue treats such a pull request as a barrier: it conflicts with
+every scope, so it is never batched or merged in parallel with other pull
+requests. `all_scopes: true` works with both `action: scopes` and
+`action: scopes-upload`, with or without concrete `scopes`, and requires
+mergify-cli 2026.7.8.1 or newer (see the `mergify_cli_version` input if the
+pinned default is older).
+
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
@@ -28,6 +65,7 @@ Need help setting it up? See the [GitHub Actions setup guide](https://docs.mergi
 | Input | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `action` | string | false | `junit-process` | The Mergify CI action:<br>• junit-process: process JUnit XML files with Mergify CI Insights (Upload and Quarantine)<br>• scopes: detect and upload pull requests scopes to Mergify Merge Queue<br>• scopes-git-refs: return the base/head git references of the pull request in Merge Queue context<br>• scopes-upload: upload pull requests scopes to Mergify Merge Queue<br>• wait-jobs: wait for specified jobs to complete before proceeding |
+| `all_scopes` | string | false | `false` | Declare that the pull request impacts all scopes (actions: scopes, scopes-upload). The Merge Queue treats such a pull request as a barrier: it conflicts with every scope, so it is never batched or merged in parallel with other pull requests. Typical use: a build-system or CI configuration change where enumerating every impacted scope is brittle. Requires mergify-cli 2026.7.8.1 or newer. |
 | `base` | string | false |  | Base git reference for scope detection (action: scopes). Overrides the automatic push/pull-request detection. Leave unset to auto-detect. |
 | `head` | string | false |  | Head git reference for scope detection (action: scopes). Defaults to HEAD. Leave unset to auto-detect. |
 | `job_name` | string | false |  | Override the job name, must be used in case of matrix job to avoid having the same name for all jobs |

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,15 @@ inputs:
     description: Path of the files to upload
   scopes:
     description: Comma separated list of scopes to upload
+  all_scopes:
+    description: |
+      Declare that the pull request impacts all scopes (actions: scopes,
+      scopes-upload). The Merge Queue treats such a pull request as a
+      barrier: it conflicts with every scope, so it is never batched or
+      merged in parallel with other pull requests. Typical use: a
+      build-system or CI configuration change where enumerating every
+      impacted scope is brittle. Requires mergify-cli 2026.7.8.1 or newer.
+    default: "false"
   mergify_config_path:
     description: Path to the Mergify configuration file
   base:
@@ -154,8 +163,9 @@ runs:
       run: |
         set -euo pipefail
         FILE="$RUNNER_TEMP/mergify-scopes.json"
-        # Convert comma-separated SCOPES into a JSON array
-        SCOPES_JSON=$(jq -R -s 'rtrimstr("\n") | split(",")' <<< "$SCOPES")
+        # Convert comma-separated SCOPES into a JSON array; an empty input
+        # yields [] (an all_scopes pull request may carry no concrete scope)
+        SCOPES_JSON=$(jq -R -s 'rtrimstr("\n") | split(",") | map(select(length > 0))' <<< "$SCOPES")
         jq -n \
           --arg base "$BASE" \
           --arg head "$HEAD" \
@@ -183,7 +193,11 @@ runs:
         MERGIFY_TOKEN: ${{ inputs.token }}
         MERGIFY_API_URL: ${{ inputs.mergify_api_url }}
         MERGIFY_CONFIG_PATH: ${{ inputs.mergify_config_path }}
-      run: mergify ci scopes-send --scopes-json $RUNNER_TEMP/mergify-scopes.json
+        ALL_SCOPES: ${{ inputs.all_scopes }}
+      run: |
+        args=(--scopes-json "$RUNNER_TEMP/mergify-scopes.json")
+        [ "$ALL_SCOPES" = "true" ] && args+=(--all)
+        mergify ci scopes-send "${args[@]}"
 
     - name: Wait jobs
       if: inputs.action == 'wait-jobs'


### PR DESCRIPTION
The scopes API now accepts an all_scopes boolean alongside the concrete
scopes list: when true, the pull request impacts every scope and the
Merge Queue treats it as a barrier — it conflicts with every scope and is
never batched or merged in parallel with other pull requests. Typical use
is a build-system or CI-workflow change where enumerating every impacted
scope is brittle. A customer (Val) asked for this directly and could not
find it in this action.

Expose it as an `all_scopes` input honored by both `action: scopes` and
`action: scopes-upload`: when true, the shared upload step appends
`--all` to `mergify ci scopes-send` (mergify-cli 2026.7.8.1 or newer).
An all-scopes pull request may carry no concrete scope, so the
scopes-upload JSON builder now maps an empty `scopes` input to `[]`
instead of `[""]`.

Document the catch-all in the README — including the barrier semantics —
so it is discoverable, and exercise the new input in CI with
`mergify_cli_version: latest` since the setup-cli pin predates the flag.

Fixes MRGFY-7885

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>