### PR TITLE
ci: exclude the semgrep renovate-missing-minimum-release-age rule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,11 @@ jobs:
         run: |
           # nosemgrep: generic.ci.security.use-frozen-lockfile.use-frozen-lockfile-pip
           pip install semgrep yamllint
-          semgrep --config=auto --error
+          # The short minimumReleaseAge for our own first-party deps in
+          # renovate.json is deliberate, and the rule's suggested opt-out
+          # ("minimumReleaseAge": false) is invalid per the Renovate schema.
+          semgrep --config=auto --error \
+            --exclude-rule package_managers.renovate.renovate-missing-minimum-release-age.renovate-missing-minimum-release-age
           yamllint .
 
   autodoc:


### PR DESCRIPTION
A new semgrep community rule (v42) flags renovate.json's
`"minimumReleaseAge": "0"` for our first-party deps, breaking the
linters job on every pull request. The short release age is deliberate —
waiting out the stability window for our own freshly-released packages
is pointless — and the rule's suggested opt-out
(`"minimumReleaseAge": false`) is invalid per the Renovate schema
(string or null only), so it can't be silenced from renovate.json
without changing its behavior. Exclude the rule from the semgrep
invocation instead; renovate.json stays scanned by every other rule.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>