### PR TITLE
chore(deps): update Mergifyio/setup-cli to v1.2.0 and drop the CLI override

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,9 +86,8 @@ jobs:
           scopes: scope1,scope2
           mergify_config_path: zfixtures/mergify.yml
 
-      # all_scopes needs a mergify-cli newer than the setup-cli pin, hence
-      # mergify_cli_version: latest. No scopes input: an all-scopes pull
-      # request may carry no concrete scope, exercising the empty-list path.
+      # No scopes input: an all-scopes pull request may carry no concrete
+      # scope, exercising the empty-list path.
       - name: Trying action scopes-upload with all_scopes
         id: scopes-upload-all
         uses: ./
@@ -97,7 +96,6 @@ jobs:
           token: ${{ secrets.MERGIFY_TOKEN }}
           all_scopes: true
           mergify_config_path: zfixtures/mergify.yml
-          mergify_cli_version: latest
 
       - name: Trying action scopes
         id: scopes-detection

--- a/action.yml
+++ b/action.yml
@@ -105,13 +105,13 @@ runs:
     # Hence two variants: forward an explicit value, or call with no version.
     - name: Setup Mergify CLI 🔧
       if: inputs.mergify_cli_version != ''
-      uses: Mergifyio/setup-cli@2440cd0d54c1350f0a72b42952146c95b46d1623 # v1
+      uses: Mergifyio/setup-cli@8d75e33f675ccf0333866a1a972649e130a8a047 # v1.2.0
       with:
         mergify_cli_version: ${{ inputs.mergify_cli_version }}
 
     - name: Setup Mergify CLI (pinned default) 🔧
       if: inputs.mergify_cli_version == ''
-      uses: Mergifyio/setup-cli@2440cd0d54c1350f0a72b42952146c95b46d1623 # v1
+      uses: Mergifyio/setup-cli@8d75e33f675ccf0333866a1a972649e130a8a047 # v1.2.0
 
     - shell: bash
       id: junit-process


### PR DESCRIPTION
setup-cli v1.2.0 bumps its default mergify-cli to 2026.7.8.1, which ships
`scopes-send --all`. The all_scopes CI test no longer needs its
`mergify_cli_version: latest` override: the pinned default now supports
the flag, so the test exercises what users actually get.

Fixes MRGFY-8004

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>