### PR TITLE
fix(junit-process): quote report_path and terminate option parsing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,6 +136,23 @@ jobs:
           mergify_api_url: http://localhost:1080
           mergify_config_path: zfixtures/mergify.yml
 
+      # A report path that looks like a CLI option must stay an operand. The
+      # pattern needs a leading wildcard: a prefix-anchored one can never
+      # expand to a token starting with `-`.
+      - name: Prepare option-lookalike report fixture
+        run: |
+          mkdir -p './--api-url=http:_example.invalid'
+          cp zfixtures/junit_example.xml './--api-url=http:_example.invalid/junit_x.xml'
+
+      - name: Run action with an option-lookalike report path
+        uses: ./
+        with:
+          action: junit-process
+          token: fake-valid-token
+          report_path: "*/junit_x.xml"
+          mergify_api_url: http://localhost:1080
+          mergify_config_path: zfixtures/mergify.yml
+
       - name: Run action with error scenario ❌
         id: error500
         continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,11 @@ runs:
         FILES: ${{ inputs.report_path }}
       run: |
         set -x -e
-        mergify ci junit-process ${FILES}
+        if [ -z "$FILES" ]; then
+          echo "::error::report_path is required for action: junit-process"
+          exit 1
+        fi
+        mergify ci junit-process -- "$FILES"
 
     - name: Detect head sha and base sha
       if: inputs.action == 'scopes-git-refs' || inputs.action == 'scopes-upload'


### PR DESCRIPTION
The junit-process step ran `mergify ci junit-process ${FILES}` with an
unquoted expansion, so bash split and glob-expanded `report_path` into
argv. `mergify ci junit-process` declares `--api-url` / `-u` next to its
positional `<FILE>...` and clap allows interspersed options, so a match
starting with `-` was parsed as an option rather than a report path.

Pass `-- "$FILES"` instead: `--` terminates option parsing, and quoting
hands the pattern to the CLI, whose `expand_files` resolves it into path
operands that can never re-enter argument parsing.

Quoting also means an unset `report_path` reaches the CLI as one empty
operand instead of no operand at all, turning a "required argument
missing" error into a misleading "JUnit XML file '' does not exist,
check that your test step produced it". Guard the input explicitly so
the failure names the real problem.

Two behaviour changes ride along:

* `report_path` is now a single path or pattern. Space-separated lists
  worked only through shell word splitting and were never documented.
* `**` becomes truly recursive. Bash without globstar treated
  `**/junit*.xml` as one directory deep; the CLI's glob crate walks the
  whole tree, so the README example now matches more files.

Fixes MRGFY-8264