### PR TITLE
chore: exclude renovate[bot] from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,3 +3,4 @@ changelog:
     authors:
       - dependabot[bot]
       - mergify[bot]
+      - renovate[bot]


### PR DESCRIPTION
`.github/release.yml` already excluded `dependabot[bot]` and
`mergify[bot]`, but Renovate — not Dependabot — is the dependency bot
actually running on this repo. Of the last 100 merged PRs,
`renovate[bot]` authored 35 (`dependabot[bot]`: zero), so the notes
produced by GitHub's "Generate release notes" button are mostly dep-bump
noise.

Add `renovate[bot]` to `changelog.exclude.authors`. Verified against the
REST API that the author login GitHub matches is exactly `renovate[bot]`
(user id 29139614, type Bot) — `gh` displays it as `app/renovate`, which
is not the login. No human contributor login collides with it; the human
authors in that window are jd, sileht, kozlek and remyduthu.