### PR TITLE
fix(junit-process): send job_name as MERGIFY_TEST_JOB_NAME

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,38 @@ jobs:
           report_path: zfixtures/*.xml
           mergify_api_url: http://localhost:1080
           mergify_config_path: zfixtures/mergify.yml
+          job_name: job-name-input-probe
+
+      # job_name has no locally observable effect: it either reaches the
+      # upload as the mergify.test.job.name span attribute, or it does
+      # nothing at all. It did nothing from the day it was added until
+      # MRGFY-8734, because it was wired to an env var the CLI never reads,
+      # and only the uploaded payload tells the two apart. The payload is
+      # OTLP protobuf; attribute keys and values are plain UTF-8 inside it,
+      # so grepping the decoded bytes is enough.
+      - name: Verify job_name reached the upload
+        env:
+          JOB_NAME: job-name-input-probe
+        run: |
+          set -euo pipefail
+          curl -sf -X PUT \
+            "http://localhost:1080/mockserver/retrieve?type=REQUESTS&format=json" \
+            -d "{}" > "$RUNNER_TEMP/requests.json"
+          found=0
+          n=0
+          for payload in $(jq -r '.[].body.base64Bytes // empty' "$RUNNER_TEMP/requests.json"); do
+            n=$((n + 1))
+            body="$RUNNER_TEMP/payload-$n.bin"
+            printf '%s' "$payload" | base64 -d > "$body"
+            if grep -aq "mergify.test.job.name" "$body" \
+              && grep -aq "$JOB_NAME" "$body"; then
+              found=1
+            fi
+          done
+          if [ "$found" -ne 1 ]; then
+            echo "::error::job_name did not reach the upload as mergify.test.job.name"
+            exit 1
+          fi
 
       # A report path that looks like a CLI option must stay an operand. The
       # pattern needs a leading wildcard: a prefix-anchored one can never

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
       env:
         MERGIFY_API_URL: ${{ inputs.mergify_api_url }}
         MERGIFY_TOKEN: ${{ inputs.token }}
-        MERGIFY_JOB_NAME: ${{ inputs.job_name }}
+        MERGIFY_TEST_JOB_NAME: ${{ inputs.job_name }}
         MERGIFY_TEST_EXIT_CODE: >-
           ${{ inputs.test_step_outcome == 'success' && '0'
           || (inputs.test_step_outcome == 'failure'


### PR DESCRIPTION
The `job_name` input was mapped to `MERGIFY_JOB_NAME`, which the CLI has
never read. It reads `MERGIFY_TEST_JOB_NAME` and nothing else — there is no
equivalent flag, so the env var is the whole interface, and a near-miss name
fails silently. The input has therefore been a no-op since it was added in
#44, three months after the CLI settled on the name it still uses.

That makes the documented matrix setup dead: every leg reports the same
`GITHUB_JOB`, and `job_name` is exactly what the docs tell users to set to
tell the legs apart, so no one has ever managed to.

Verified against a local mockserver with the released CLI (2026.8.11.1):
with `MERGIFY_TEST_JOB_NAME` the uploaded OTLP payload carries the
`mergify.test.job.name` attribute; with `MERGIFY_JOB_NAME` the attribute is
absent from the payload entirely.

CI now asserts that end to end, since that is the only place the input is
observable — the junit-process step passes a `job_name` and a following step
greps the payload mockserver recorded. It fails on the old env var and
passes on the new one.

MRGFY-8734